### PR TITLE
Check if message.extra_tags is not None.

### DIFF
--- a/password_expire/middleware.py
+++ b/password_expire/middleware.py
@@ -46,6 +46,6 @@ class PasswordExpireMiddleware:
         storage = messages.get_messages(request)
         for message in storage:
             # only add this message once
-            if 'password_expire' in message.extra_tags:
+            if message.extra_tags is not None and 'password_expire' in message.extra_tags:
                 return
         messages.warning(request, text, extra_tags='password_expire')


### PR DESCRIPTION
When adding the password expired warning, I had an instance where message.extra_tags was None. This ensures extra_tags is not None before checking for password_expire in extra_tags.